### PR TITLE
Implement VCRReplaySearch modes: SearchAll, SkipFound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvcr"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Record-and-replay HTTP testing for requests"
 authors = ["tech@chorus.one"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To record HTTP requests, initialize client like following
   use rvcr::{VCRMiddleware, VCRMode};
 
   let mut bundle = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-  bundle.push("tests/resources/test.vcr");
+  bundle.push("tests/resources/replay.vcr.json");
 
   let middleware: VCRMiddleware = VCRMiddleware::try_from(bundle.clone())
       .unwrap()
@@ -35,7 +35,14 @@ To record HTTP requests, initialize client like following
 ```
 
 Now `ClientWithMiddleware` instance will be recording requests to a file
-located in `tests/resources/test.vcr` inside the project.
+located in `tests/resources/replay.vcr.json` inside the project.
 
 To use recorded VCR cassette files, replace `.with_mode(VCRMode::Record)`
 with `.with_mode(VCRMode::Replay)`, or omit it, since replay is used by default.
+
+## Search mode
+
+When replaying, rVCR can skip requests already found when searching for
+subsequent requests (the default). To disable skipping requests,
+which is useful, for example, if requests are done in parallel and responses
+may come in random order, use `.with_search(VCRReplaySearch::SearchAll)`.

--- a/tests/resources/replay.vcr.json
+++ b/tests/resources/replay.vcr.json
@@ -18,20 +18,20 @@
           "access-control-allow-origin": [
             "*"
           ],
-          "connection": [
-            "keep-alive"
+          "content-length": [
+            "170"
           ],
           "server": [
             "gunicorn/19.9.0"
-          ],
-          "content-length": [
-            "170"
           ],
           "content-type": [
             "application/json"
           ],
           "date": [
-            "Thu, 27 Apr 2023 02:21:55 GMT"
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "connection": [
+            "keep-alive"
           ]
         }
       },
@@ -48,7 +48,7 @@
           ]
         }
       },
-      "recorded_at": "Thu, 27 Apr 2023 02:21:55 +0000"
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
     },
     {
       "response": {
@@ -62,11 +62,8 @@
           "message": "OK"
         },
         "headers": {
-          "server": [
-            "gunicorn/19.9.0"
-          ],
-          "date": [
-            "Thu, 27 Apr 2023 02:21:55 GMT"
+          "access-control-allow-credentials": [
+            "true"
           ],
           "connection": [
             "keep-alive"
@@ -74,14 +71,17 @@
           "access-control-allow-origin": [
             "*"
           ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
           "content-type": [
             "application/json"
           ],
-          "access-control-allow-credentials": [
-            "true"
-          ],
           "content-length": [
             "267"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
           ]
         }
       },
@@ -98,7 +98,7 @@
           ]
         }
       },
-      "recorded_at": "Thu, 27 Apr 2023 02:21:55 +0000"
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
     },
     {
       "response": {
@@ -112,26 +112,26 @@
           "message": "OK"
         },
         "headers": {
+          "content-type": [
+            "application/json"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
           "date": [
-            "Thu, 27 Apr 2023 02:21:55 GMT"
+            "Sun, 30 Apr 2023 02:58:45 GMT"
           ],
           "connection": [
             "keep-alive"
           ],
-          "content-type": [
-            "application/json"
-          ],
           "server": [
             "gunicorn/19.9.0"
-          ],
-          "access-control-allow-origin": [
-            "*"
           ],
           "content-length": [
             "267"
           ],
-          "access-control-allow-credentials": [
-            "true"
+          "access-control-allow-origin": [
+            "*"
           ]
         }
       },
@@ -148,7 +148,7 @@
           ]
         }
       },
-      "recorded_at": "Thu, 27 Apr 2023 02:21:55 +0000"
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
     }
   ],
   "recorded_with": "rVCR 0.1.0"

--- a/tests/resources/search-all.vcr.json
+++ b/tests/resources/search-all.vcr.json
@@ -1,0 +1,247 @@
+{
+  "http_interactions": [
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/get\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "content-length": [
+            "170"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/get",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "get",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"test93\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Content-Length\": \"6\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "content-length": [
+            "268"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": "test93"
+        },
+        "method": "post",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"test93\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Content-Length\": \"6\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "content-length": [
+            "268"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": "test93"
+        },
+        "method": "post",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "content-length": [
+            "221"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "content-type": [
+            "application/json"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "post",
+        "headers": {}
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-length": [
+            "221"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:46 GMT"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "post",
+        "headers": {}
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:46 +0000"
+    }
+  ],
+  "recorded_with": "rVCR 0.1.0"
+}

--- a/tests/resources/skip-found.vcr.json
+++ b/tests/resources/skip-found.vcr.json
@@ -1,0 +1,247 @@
+{
+  "http_interactions": [
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/get\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-length": [
+            "170"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "connection": [
+            "keep-alive"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/get",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "get",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"test93\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Content-Length\": \"6\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-type": [
+            "application/json"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "content-length": [
+            "268"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": "test93"
+        },
+        "method": "post",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"test93\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json\", \n    \"Content-Length\": \"6\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-type": [
+            "application/json"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "content-length": [
+            "268"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": "test93"
+        },
+        "method": "post",
+        "headers": {
+          "accept": [
+            "application/json"
+          ]
+        }
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "server": [
+            "gunicorn/19.9.0"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "content-length": [
+            "221"
+          ],
+          "date": [
+            "Sun, 30 Apr 2023 02:58:45 GMT"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "content-type": [
+            "application/json"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "post",
+        "headers": {}
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:45 +0000"
+    },
+    {
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Host\": \"127.0.0.1:38282\"\n  }, \n  \"json\": null, \n  \"origin\": \"172.21.0.1\", \n  \"url\": \"http://127.0.0.1:38282/post\"\n}\n"
+        },
+        "http_version": "1.1",
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Sun, 30 Apr 2023 02:58:46 GMT"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-allow-credentials": [
+            "true"
+          ],
+          "content-length": [
+            "221"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "content-type": [
+            "application/json"
+          ],
+          "server": [
+            "gunicorn/19.9.0"
+          ]
+        }
+      },
+      "request": {
+        "uri": "http://127.0.0.1:38282/post",
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "method": "post",
+        "headers": {}
+      },
+      "recorded_at": "Sun, 30 Apr 2023 02:58:46 +0000"
+    }
+  ],
+  "recorded_with": "rVCR 0.1.0"
+}


### PR DESCRIPTION
Initial implementation was always skipping records which were already found when replaying.

While this provides more strict testing approach, it is only suitable when requests are coming in a predefined order.
If some requests are started in parallel, responses can come in random order too, and so skipping requests
will break the tests.

This PR adds method `.with_search(search_mode)`  and two search modes:
- `VCRReplaySearch::SkipFound`  -- skips found requests on subsequent replays, as default
- `VCRReplaySearch::SearchAll` -- always goes through all requests and returns first match

Now, tests for parallel requests can work as long as all parallel requests are having different parameters, headers or urls.
