### PR TITLE
Unpin chrono dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "rvcr"
 async-trait = "^0.1"
 base64 = "0.21.0"
 bytes = "1"
-chrono = { version = "=0.4.20", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 lazy_static = "1.4"
 reqwest = { version = "0.11" }


### PR DESCRIPTION
Since the use of `chrono` is minimal in `rvcr`,  no need to account for deprecation happened in 0.4.20+ versions.