### PR TITLE
Replay: Panic when cassette cannot be read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,23 +292,14 @@ impl Middleware for VCRMiddleware {
                 let converted_response = self.vcr_to_response(vcr_response.clone());
                 self.record(vcr_request, vcr_response);
                 Ok(converted_response)
-            }
+            },
             VCRMode::Replay => {
-                let vcr_response = self.find_response_in_vcr(vcr_request).unwrap_or(
-                    // Empty 404 response
-                    vcr_cassette::Response {
-                        body: vcr_cassette::Body::from_str("").unwrap(),
-                        http_version: Some(vcr_cassette::Version::Http1_1),
-                        status: vcr_cassette::Status {
-                            code: 404,
-                            message: "Not found in VCR".to_string(),
-                        },
-                        headers: HashMap::new(),
-                    },
+                let vcr_response = self.find_response_in_vcr(vcr_request).unwrap_or_else(||
+                    panic!("Can not read cassette contents from {:?}", self.path)
                 );
                 let response = self.vcr_to_response(vcr_response);
                 Ok(response)
-            }
+            },
         }
     }
 }


### PR DESCRIPTION
Thanks for creating `rvcr`! Here's a PR which aligns it a bit more with Ruby VCR's behaviour.

The [Ruby version of VCR](https://github.com/vcr/vcr) panics and renders a detailed error message when a cassette cannot be found or a request does not match a recording. `rvcr` instead replays a fake 404 Not Found.

Sadly, this fake 404 Not Found surprised me and led me down a false troubleshooting path as I thought it was a _real_ 404.

I'd argue that others may find it surprising too and that the behaviour regrettably can cause false positives/negatives during testing (as 404 Not Found is itself a valid case to test against but this behaviour masks it).

I realize that this is a breaking change. I'd be happy to add another "mode" to support the current behaviour, but I'd argue that panicking should be the default behaviour, so a breaking change is inevitable. Let me know if you want me to add that other mode, a `CHANGELOG` explaining the situation, a semver version bump, or any other changes required.

Thanks for reading and considering the PR!