### PR TITLE
Make debugging unmatched requests easier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ compress = ["dep:zip"]
 
 
 [dependencies]
+anyhow = "^1"
 async-trait = "^0.1"
 base64 = "0.21.0"
 bytes = "1"
@@ -42,5 +43,6 @@ vcr-cassette = "2"
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 url = "2.4"
 


### PR DESCRIPTION
Hey, thanks for the great library! I added some print statements in my fork because I found it cumbersome to debug failing tests. I can hide this logic behind a flag or something if you're interested in merging this PR