### PR TITLE
Make `VCRMode::Record` overwrite existing files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ impl VCRMiddleware {
 
     fn record(&self, request: vcr_cassette::Request, response: vcr_cassette::Response) {
         let mut cassette = self.storage.lock().unwrap();
+        cassette.http_interactions.clear();
         cassette
             .http_interactions
             .push(vcr_cassette::HttpInteraction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ pub type VCRError = &'static str;
 impl VCRMiddleware {
     /// Adjust mode in the middleware and return it
     pub fn with_mode(mut self, mode: VCRMode) -> Self {
+        if mode == VCRMode::Record {
+            let mut cassette = self.storage.lock().unwrap();
+            cassette.http_interactions.clear();
+        }
         self.mode = mode;
         self
     }
@@ -377,7 +381,6 @@ impl VCRMiddleware {
 
     fn record(&self, request: vcr_cassette::Request, response: vcr_cassette::Response) {
         let mut cassette = self.storage.lock().unwrap();
-        cassette.http_interactions.clear();
         cassette
             .http_interactions
             .push(vcr_cassette::HttpInteraction {
@@ -482,7 +485,7 @@ impl Drop for VCRMiddleware {
     }
 }
 
-/// Load VCR cassette for filesystem
+/// Load VCR cassette from filesystem
 //
 /// For simplicity, support JSON format only for now
 impl TryFrom<PathBuf> for VCRMiddleware {


### PR DESCRIPTION
Making this change to align with the documentation:

`/// Record requests to the local VCR cassette files. Existing files will be overwritten`

... and my expectation as a user coming from Ruby's VCR.

Thanks again for `rvcr`, it's great!