### PR TITLE
Use new quality-of-life improvements from vcr-cassette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,11 +1569,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "vcr-cassette"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364f53759622897886653050d8836272da6ba50f3a4f6ad7065a78ef7141554d"
+source = "git+https://github.com/mpalmer/vcr-cassette.git?branch=full-body-workout#5345e13069d9008a4b17f27ad2eb4ed367f5cbcf"
 dependencies = [
  "chrono",
+ "regex",
  "serde",
+ "serde_json",
  "url",
  "void",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ name = "rvcr"
 [features]
 default = []
 compress = ["dep:zip"]
-
+json = ["vcr-cassette/json"]
+matching = ["vcr-cassette/matching"]
+regex = ["vcr-cassette/regex"]
 
 [dependencies]
 anyhow = "^1"
@@ -46,3 +48,5 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 url = "2.4"
 
+[patch.crates-io]
+vcr-cassette = { git = "https://github.com/mpalmer/vcr-cassette.git", branch = "full-body-workout" }


### PR DESCRIPTION
This exposes the ability to provide "matchers" for request bodies, and specify your JSON response bodies as JSON, new features recently added to `vcr-cassette`.

(Merge note: this PR depends on http-rs/vcr-cassette#22; the `patch.crates-io` reflects that, for CI purposes.  I will force-push a version without that change to `Cargo.toml` before merge)